### PR TITLE
Capture config for QuickfixJ Application-level messages

### DIFF
--- a/quickfix-app-messages.xml
+++ b/quickfix-app-messages.xml
@@ -1,0 +1,10 @@
+<capture-points>
+  <capture-point enabled="true" 
+  
+    class-name="quickfix.Session" method-name="toApp" 
+    insert-class-name="quickfix.Session" insert-method-name="next" 
+
+    capture-key-expression="message.getHeader().getField(49).getValue() + &quot;-&gt;&quot; + message.getHeader().getField(56).getValue() + &quot;#&quot; + message.getHeader().getField(34).getValue()" 
+    insert-key-expression ="message.getHeader().getField(49).getValue() + &quot;-&gt;&quot; + message.getHeader().getField(56).getValue() + &quot;#&quot; + message.getHeader().getField(34).getValue()" 
+  />
+</capture-points>


### PR DESCRIPTION
Useful for testing use-cases when with both endpoints of a fix session are in the same JVM.